### PR TITLE
Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 <!-- markdownlint-disable MD033 -->
 <!-- BEGIN_TF_DOCS -->
-# EC2 Module
-
-- Creating EC2 instance
-- Creating Auto Scaling Group
-- Provides an EC2 launch template resource. Can be used to create instances or auto scaling groups.
-
-## Requirements
+## Requirementsw
 
 | Name | Version |
 |------|---------|
@@ -57,19 +51,19 @@
 | <a name="input_autoscaling_subnets"></a> [autoscaling\_subnets](#input\_autoscaling\_subnets) | description | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_autoscaling_target_group_arns"></a> [autoscaling\_target\_group\_arns](#input\_autoscaling\_target\_group\_arns) | A set of aws\_alb\_target\_group ARNs, for use with Application or Network Load Balancing. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_block_device_mappings"></a> [block\_device\_mappings](#input\_block\_device\_mappings) | Specify volumes to attach to the instance besides the volumes specified by the AMI | <pre>list(object({<br>    device_name  = string<br>    no_device    = bool<br>    virtual_name = string<br>    ebs = object({<br>      delete_on_termination = bool<br>      encrypted             = bool<br>      iops                  = number<br>      kms_key_id            = string<br>      snapshot_id           = string<br>      volume_size           = number<br>      volume_type           = string<br>    })<br>  }))</pre> | `[]` | no |
-| <a name="input_create_attachment_role"></a> [create\_attachment\_role](#input\_create\_attachment\_role) | if true, enable create attachment rol | `bool` | `false` | no |
+| <a name="input_create_attachment_role"></a> [create\_attachment\_role](#input\_create\_attachment\_role) | if true, enable create attachment role | `bool` | `false` | no |
 | <a name="input_create_autoscaling_group"></a> [create\_autoscaling\_group](#input\_create\_autoscaling\_group) | n/a | `bool` | `false` | no |
-| <a name="input_create_autoscaling_schedule_down"></a> [create\_autoscaling\_schedule\_down](#input\_create\_autoscaling\_schedule\_down) | if this valus is true, you'll create a schedule\_down | `bool` | `false` | no |
-| <a name="input_create_autoscaling_schedule_up"></a> [create\_autoscaling\_schedule\_up](#input\_create\_autoscaling\_schedule\_up) | if this valus is true, you'll create a schedule\_up | `bool` | `false` | no |
+| <a name="input_create_autoscaling_schedule_down"></a> [create\_autoscaling\_schedule\_down](#input\_create\_autoscaling\_schedule\_down) | if set to true, you'll create a schedule\_down | `bool` | `false` | no |
+| <a name="input_create_autoscaling_schedule_up"></a> [create\_autoscaling\_schedule\_up](#input\_create\_autoscaling\_schedule\_up) | if set to true true, you'll create a schedule\_up | `bool` | `false` | no |
 | <a name="input_create_ec2"></a> [create\_ec2](#input\_create\_ec2) | description | `bool` | `false` | no |
 | <a name="input_create_eip"></a> [create\_eip](#input\_create\_eip) | Creates EIPs for the instances when create\_ec2 is True | `bool` | `false` | no |
 | <a name="input_create_eip_association"></a> [create\_eip\_association](#input\_create\_eip\_association) | Creates EIPs for the instances when create\_ec2 is True | `bool` | `false` | no |
 | <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | n/a | `bool` | `false` | no |
 | <a name="input_create_key_pair"></a> [create\_key\_pair](#input\_create\_key\_pair) | if true, enable create key pair | `bool` | `false` | no |
-| <a name="input_create_lauch_template"></a> [create\_lauch\_template](#input\_create\_lauch\_template) | description | `bool` | `false` | no |
-| <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | if true, enable create rol | `bool` | `false` | no |
+| <a name="input_create_launch_template"></a> [create\_launch\_template](#input\_create\_launch\_template) | description | `bool` | `false` | no |
+| <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | if true, enable create role | `bool` | `false` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | n/a | `bool` | `false` | no |
-| <a name="input_create_sg"></a> [create\_sg](#input\_create\_sg) | if true, enable create security gruop | `bool` | `false` | no |
+| <a name="input_create_sg"></a> [create\_sg](#input\_create\_sg) | if true, enable create security group | `bool` | `false` | no |
 | <a name="input_create_target_group_attachment"></a> [create\_target\_group\_attachment](#input\_create\_target\_group\_attachment) | description | `bool` | `false` | no |
 | <a name="input_down_end_time"></a> [down\_end\_time](#input\_down\_end\_time) | description | `string` | `null` | no |
 | <a name="input_down_recurrence"></a> [down\_recurrence](#input\_down\_recurrence) | description | `string` | `""` | no |
@@ -105,11 +99,11 @@
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | IAM Role profile name for instance | `string` | `""` | no |
 | <a name="input_instance_profile_role"></a> [instance\_profile\_role](#input\_instance\_profile\_role) | description | `string` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The name for the key pair. | `string` | `""` | no |
-| <a name="input_name_lauch_template"></a> [name\_lauch\_template](#input\_name\_lauch\_template) | description | `string` | `""` | no |
+| <a name="input_name_launch_template"></a> [name\_launch\_template](#input\_name\_launch\_template) | description | `string` | `""` | no |
 | <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | n/a | `string` | `null` | no |
 | <a name="input_public_key"></a> [public\_key](#input\_public\_key) | The public key material. | `string` | `""` | no |
 | <a name="input_sg_vpc_id"></a> [sg\_vpc\_id](#input\_sg\_vpc\_id) | n/a | `string` | `""` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | all tags for all recursives | `any` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | all tags for all recursively | `any` | `null` | no |
 | <a name="input_target_group"></a> [target\_group](#input\_target\_group) | list ARN of target Groups | `any` | `[]` | no |
 | <a name="input_time_zone"></a> [time\_zone](#input\_time\_zone) | Time zone selection for instance | `string` | `null` | no |
 | <a name="input_up_end_time"></a> [up\_end\_time](#input\_up\_end\_time) | description | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 <!-- markdownlint-disable MD033 -->
 <!-- BEGIN_TF_DOCS -->
-## Requirementsw
+# EC2 Module
+
+- Creating EC2 instance
+- Creating Auto Scaling Group
+- Provides an EC2 launch template resource. Can be used to create instances or auto scaling groups.
+
+## Requirements
 
 | Name | Version |
 |------|---------|

--- a/examples/ec2_only/terragrunt/ec2/terragrun.hcl
+++ b/examples/ec2_only/terragrunt/ec2/terragrun.hcl
@@ -38,10 +38,11 @@ inputs = {
 
   ec2_sg_ingress_rules = [
     {
-      description = "load blancer"
+      description = "load balancer"
       from_port   = 22
       to_port     = 22
       cidr_blocks = ["0.0.0.0/0"]
       protocol    = "tcp"
     }
-]
+  ]
+}

--- a/examples/ec2_with_policy/terragrunt/ec2/terragrunt.hcl
+++ b/examples/ec2_with_policy/terragrunt/ec2/terragrunt.hcl
@@ -42,7 +42,7 @@ inputs = {
 
   ec2_sg_ingress_rules = [
     {
-      description = "load blancer"
+      description = "load balancer"
       from_port   = 22
       to_port     = 22
       cidr_blocks = ["0.0.0.0/0"]

--- a/examples/launch_template/terragrunt/ec2/terragrun.hcl
+++ b/examples/launch_template/terragrunt/ec2/terragrun.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 dependency "data" {
-  config_path = "../data+"
+  config_path = "../data"
 }
 
 terraform {
@@ -15,11 +15,11 @@ terraform {
 }
 
 inputs = {
-  create_lauch_template           = true
+  create_launch_template           = true
   ec2_associate_public_ip_address = true
   create_key_pair                 = true
   create_sg                       = true
-  name_lauch_template             = "example"
+  name_launch_template             = "example"
   autoscaling_name                = "example"
   ec2_name                        = "example"
   key_name                        = "example" 
@@ -52,12 +52,11 @@ inputs = {
 
   ec2_sg_ingress_rules = [
     {
-      description = "load blancer"
+      description = "load balancer"
       from_port   = 22
       to_port     = 22
       cidr_blocks = ["0.0.0.0/0"]
       protocol    = "tcp"
     }
   ]
-
 }

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "ec2_instance" {
   subnet_id                   = var.ec2_subnet_id
   user_data                   = var.ec2_user_data
   user_data_base64            = var.ec2_user_data != null ? null : var.ec2_user_data_base64
-  hibernation                 = var.ec2_hibernation  
+  hibernation                 = var.ec2_hibernation
   iam_instance_profile        = var.create_iam_instance_profile ? element(concat(aws_iam_instance_profile.this.*.id, [""]), 0) : var.instance_profile_name != "" ? var.instance_profile_name : null
   associate_public_ip_address = var.ec2_associate_public_ip_address
   private_ip                  = var.ec2_private_ip
@@ -154,7 +154,7 @@ resource "aws_security_group" "ec2_sg" {
 }
 
 resource "aws_launch_template" "this" {
-  count = var.create_lauch_template ? 1 : 0
+  count = var.create_launch_template ? 1 : 0
 
   name_prefix   = var.ec2_name
   ebs_optimized = var.ec2_ebs_optimized
@@ -236,12 +236,12 @@ resource "aws_launch_template" "this" {
 resource "aws_autoscaling_group" "this" {
   count = var.create_autoscaling_group && var.autoscaling_name != "" ? 1 : 0
 
-  name                = var.autoscaling_name
-  vpc_zone_identifier = var.autoscaling_subnets
-  max_size            = var.autoscaling_max_size
-  min_size            = var.autoscaling_min_size
-  desired_capacity    = var.autoscaling_desired_capacity
-  target_group_arns   = var.autoscaling_target_group_arns
+  name                      = var.autoscaling_name
+  vpc_zone_identifier       = var.autoscaling_subnets
+  max_size                  = var.autoscaling_max_size
+  min_size                  = var.autoscaling_min_size
+  desired_capacity          = var.autoscaling_desired_capacity
+  target_group_arns         = var.autoscaling_target_group_arns
   health_check_grace_period = var.health_check_grace_period
   #termination_policies    = var.termination_policies
   #enabled_metrics         = var.enabled_metrics
@@ -268,7 +268,7 @@ resource "aws_autoscaling_schedule" "up" {
   start_time             = var.up_star_time
   end_time               = var.up_end_time
   autoscaling_group_name = element(concat(aws_autoscaling_group.this.*.name, [""]), 0)
-  time_zone = var.time_zone
+  time_zone              = var.time_zone
 }
 
 resource "aws_autoscaling_schedule" "down" {
@@ -281,5 +281,5 @@ resource "aws_autoscaling_schedule" "down" {
   start_time             = var.down_star_time
   end_time               = var.down_end_time
   autoscaling_group_name = element(concat(aws_autoscaling_group.this.*.name, [""]), 0)
-  time_zone = var.time_zone
+  time_zone              = var.time_zone
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 locals {
-  name_instance = var.create_lauch_template ? var.ec2_name : ""
+  name_instance = var.create_launch_template ? var.ec2_name : ""
 }
 
 output "id" {
@@ -30,7 +30,7 @@ output "id_security_group" {
 
 output "name_autoscaling" {
   description = "Name of the Auto Scaling Group"
-  value = element(concat(aws_autoscaling_group.this.*.name, [""]), 0)
+  value       = element(concat(aws_autoscaling_group.this.*.name, [""]), 0)
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "public_key" {
 variable "create_sg" {
   type        = bool
   default     = false
-  description = "if true, enable create security gruop"
+  description = "if true, enable create security group"
 }
 
 variable "ec2_sg_ingress_rules" {
@@ -150,19 +150,19 @@ variable "ec2_sg_egress_rules" {
 variable "tags" {
   type        = any
   default     = null
-  description = "all tags for all recursives"
+  description = "all tags for all recursively"
 }
 
 variable "create_attachment_role" {
   type        = bool
   default     = false
-  description = "if true, enable create attachment rol"
+  description = "if true, enable create attachment role"
 }
 
 variable "create_policy" {
   type        = bool
   default     = false
-  description = "if true, enable create rol"
+  description = "if true, enable create role"
 }
 
 variable "policy_json" {
@@ -177,7 +177,7 @@ variable "sg_vpc_id" {
   description = ""
 }
 
-variable "name_lauch_template" {
+variable "name_launch_template" {
   type        = string
   default     = ""
   description = "description"
@@ -219,7 +219,7 @@ variable "create_ec2" {
   description = "description"
 }
 
-variable "create_lauch_template" {
+variable "create_launch_template" {
   type        = bool
   default     = false
   description = "description"
@@ -350,19 +350,19 @@ variable "eip_association_allocation_id" {
 variable "autoscaling_target_group_arns" {
   type        = list(string)
   default     = [""]
-  description = " A set of aws_alb_target_group ARNs, for use with Application or Network Load Balancing."
+  description = "A set of aws_alb_target_group ARNs, for use with Application or Network Load Balancing."
 }
 
 variable "create_autoscaling_schedule_down" {
   type        = bool
   default     = false
-  description = "if this valus is true, you'll create a schedule_down"
+  description = "if set to true, you'll create a schedule_down"
 }
 
 variable "create_autoscaling_schedule_up" {
   type        = bool
   default     = false
-  description = "if this valus is true, you'll create a schedule_up"
+  description = "if set to true true, you'll create a schedule_up"
 }
 
 variable "ec2_subnet_ids" {


### PR DESCRIPTION
# Changes
- Fixed some typos on variable's descriptions in variables.tf
- Changed 2 variable names in variables.tf
- Fixed a syntax problem in ec2_only example, some missing "}" at the end of the file
- Fixed some typos in all examples
- Regenerated README with all changes

## Changes in variables
```
create_lauch_template  ->  create_launch_template
name_lauch_template    ->  name_launch_template 
```
This might break someone's code.